### PR TITLE
Fix get by family function

### DIFF
--- a/src/__tests__/main.spec.ts
+++ b/src/__tests__/main.spec.ts
@@ -1,4 +1,4 @@
-import { getByName, calculateRank } from '../index';
+import { getByName, calculateRank, getByFamily } from '../index';
 
 describe('general-test', () => {
   it('should generate ranking', () => {
@@ -65,5 +65,14 @@ describe('general-test', () => {
         },
       ]),
     );
+  });
+
+  it('should return family', () => {
+    const pokedexEntry = getByName({ name: 'Machamp' });
+    const pokemonFamily = getByFamily({ name: pokedexEntry.family });
+    expect(pokemonFamily).toHaveLength(3);
+    expect(pokemonFamily[0].name).toEqual('Machop');
+    expect(pokemonFamily[1].name).toEqual('Machoke');
+    expect(pokemonFamily[2].name).toEqual('Machamp');
   });
 });

--- a/src/pokedex.ts
+++ b/src/pokedex.ts
@@ -6143,6 +6143,6 @@ export function getByName({ name }: PokedexSearchRequest): PokedexEntry {
 }
 
 export const getByFamily = ({ name }: PokedexSearchRequest): PokedexEntry[] =>
-  pokedex.filter(pokemon => pokemon.name === name);
+  pokedex.filter(pokemon => pokemon.family === name);
 
 export default pokedex;


### PR DESCRIPTION
Fixes that the `getByFamily` function filters out Pokemon based on `name` when it should do it by `family`. Also added a test for `getByFamily`.

Great package btw 😄 